### PR TITLE
PBL-25447: App Message transaction IDs overflowing

### DIFF
--- a/libpebble2/services/appmessage.py
+++ b/libpebble2/services/appmessage.py
@@ -133,7 +133,7 @@ class AppMessageService(EventSourceMixin):
         self._pebble.unregister_endpoint(self._handle)
 
     def _get_txid(self):
-        self._current_txid += 1
+        self._current_txid = (self._current_txid + 1) % 0xff
         return self._current_txid
 
 


### PR DESCRIPTION
- Wrap around transaction ID to limit the value to what can be stored in one byte.
- Verified that jsspeedtest-100b-infinite.pbw does not crash libpebble2 when rolling over from transaction ID 0xff to 0x00
