### PR TITLE
Fix log dump shipping protocol

### DIFF
--- a/libpebble2/protocol/logs.py
+++ b/libpebble2/protocol/logs.py
@@ -4,7 +4,7 @@ __author__ = 'katharine'
 from .base import PebblePacket
 from .base.types import *
 
-__all__ = ["RequestLogs", "LogMessage", "LogMessageDone", "NoLogMessages", "LogShipping", "AppLogShippingControl",
+__all__ = ["RequestLogs", "LogMessage", "LogMessageDone", "NoLogMessages", "LogDumpShipping", "AppLogShippingControl",
            "AppLogMessage"]
 
 # Flash log messages
@@ -33,9 +33,9 @@ class NoLogMessages(PebblePacket):
     cookie = Uint32()
 
 
-class LogShipping(PebblePacket):
+class LogDumpShipping(PebblePacket):
     class Meta:
-        endpoint = 2000
+        endpoint = 2002
 
     command = Uint8()
     data = Union(command, {


### PR DESCRIPTION
It looks like there was a mix up between this protocol (the "Log Dump
Shipping" protocol, used for collecting historical debug logs) and
another now non-existent protocol (the "Log Shipping" protocol, where
firmware logs were streamed over bluetooth in real time). Fix up the
mix up.
