### PR TITLE
App Glances

### DIFF
--- a/libpebble2/protocol/appglance.py
+++ b/libpebble2/protocol/appglance.py
@@ -1,0 +1,64 @@
+from __future__ import absolute_import
+__author__ = 'katharine'
+
+"""
+This file is special in that it actually contains definitions of
+blobdb blob formats rather than pebble protocol messages.
+"""
+
+from copy import deepcopy
+from enum import IntEnum
+
+from .base import PebblePacket
+from .base.types import *
+from .timeline import TimelineAttribute
+
+import struct
+
+__all__ = ["AppGlanceSliceIconAndSubtitle", "AppGlance"]
+
+
+class AppGlanceSliceType(IntEnum):
+    IconAndSubtitle = 0
+
+
+class AppGlanceSlice(PebblePacket):
+
+    def __init__(self, expiration_time, slice_type, extra_attributes=None):
+        attributes = deepcopy(extra_attributes)
+        attributes.append(TimelineAttribute(attribute_id=37, content=struct.pack('<I', expiration_time)))
+
+        # Add 4 bytes to account for total_size (2), type (1), and attribute_count (1)
+        total_size = 4 + sum([len(attribute.serialise()) for attribute in attributes])
+
+        super(AppGlanceSlice, self).__init__(total_size=total_size, type=slice_type, attribute_count=len(attributes),
+                                             attributes=attributes)
+
+    class Meta:
+        endianness = '<'
+
+    total_size = Uint16()
+    type = Uint8(enum=AppGlanceSliceType)
+    attribute_count = Uint8()
+    attributes = FixedList(TimelineAttribute, count=attribute_count)
+
+
+class AppGlanceSliceIconAndSubtitle(AppGlanceSlice):
+
+    def __init__(self, expiration_time, icon_resource_id=None, subtitle=None):
+        attributes = []
+        if icon_resource_id:
+            attributes.append(TimelineAttribute(attribute_id=4, content=struct.pack('<I', icon_resource_id)))
+        if subtitle:
+            attributes.append(TimelineAttribute(attribute_id=47, content=subtitle.encode('utf-8')))
+        super(AppGlanceSliceIconAndSubtitle, self).__init__(expiration_time, AppGlanceSliceType.IconAndSubtitle,
+                                                            extra_attributes=attributes)
+
+
+class AppGlance(PebblePacket):
+    class Meta:
+        endianness = '<'
+
+    version = Uint8()
+    creation_time = Uint32()
+    slices = FixedList(AppGlanceSlice)

--- a/libpebble2/protocol/appglance.py
+++ b/libpebble2/protocol/appglance.py
@@ -25,7 +25,9 @@ class AppGlanceSliceType(IntEnum):
 class AppGlanceSlice(PebblePacket):
 
     def __init__(self, expiration_time, slice_type, extra_attributes=None):
-        attributes = deepcopy(extra_attributes)
+        attributes = []
+        if extra_attributes:
+            attributes.extend(deepcopy(extra_attributes))
         attributes.append(TimelineAttribute(attribute_id=37, content=struct.pack('<I', expiration_time)))
 
         # Add 4 bytes to account for total_size (2), type (1), and attribute_count (1)

--- a/libpebble2/protocol/blobdb.py
+++ b/libpebble2/protocol/blobdb.py
@@ -32,6 +32,7 @@ class BlobDatabaseID(IntEnum):
     App = 2
     Reminder = 3
     Notification = 4
+    AppGlance = 11
 
 
 class BlobCommand(PebblePacket):

--- a/libpebble2/services/appglances.py
+++ b/libpebble2/services/appglances.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+__author__ = 'katharine'
+
+from libpebble2.protocol.appglance import *
+from libpebble2.protocol.blobdb import BlobDatabaseID
+from libpebble2.services.blobdb import BlobDBClient, SyncWrapper
+
+import time
+
+
+class AppGlances(object):
+    """
+    Reloads app glances.
+
+    .. note:
+       If a :class:`BlobDBClient` already exists for the given :class:`PebbleConnection`, you should pass that in here
+       to avoid conflicts.
+
+    :param pebble: The Pebble to send an app glance reload message to.
+    :type pebble: .PebbleConnection
+    :param blobdb: An existing :class:`BlobDBClient`, if any. If necessary, one will be created.
+    """
+    def __init__(self, pebble, blobdb=None):
+        self._pebble = pebble
+        self._blobdb = blobdb or BlobDBClient(pebble)
+
+    def reload_glance(self, target_app, slices=None):
+        """
+        Reloads an app's glance. Blocks as long as necessary.
+
+        :param target_app: The UUID of the app for which to reload its glance.
+        :type target_app: ~uuid.UUID
+        :param slices: The slices with which to reload the app's glance.
+        :type slices: list[.AppGlanceSlice]
+        """
+        glance = AppGlance(
+            version=1,
+            creation_time=time.time(),
+            slices=(slices or [])
+        )
+        SyncWrapper(self._blobdb.insert, BlobDatabaseID.AppGlance, target_app, glance.serialise()).wait()


### PR DESCRIPTION
Adds support for app glances via a new `appglances` service. I also added the app glance database ID to the BlobDB database ID enum and created `PebblePacket` subclasses for the packets that the app glance service uses.

Example:

```
import libpebble2.services.appglances
import time
import uuid
from libpebble2.communication import PebbleConnection
from libpebble2.communication.transports.qemu import QemuTransport
from libpebble2.protocol.appglance import AppGlanceSliceIconAndSubtitle
from libpebble2.protocol.system import SetUTC, TimeMessage

transport = QemuTransport('127.0.0.1')
pebble = PebbleConnection(transport)
pebble.connect()
pebble.run_async()

ag = libpebble2.services.appglances.AppGlances(pebble)

# By default the emulator uses local time, but time.time() reports UTC, so set
# the emulator time to UTC
current_time = time.time()
pebble.send_packet(TimeMessage(message=SetUTC(unix_time=current_time, utc_offset=0,
                                              tz_name="UTC+0")))

# Expire 10 seconds from now
expiration_time = current_time + 10

# Some system icon on Pebble Time
icon_resource_id = 24

subtitle = 'Hello glance!'

my_slices = [AppGlanceSliceIconAndSubtitle(expiration_time, icon_resource_id, subtitle)]

watchfaces_app_uuid = uuid.UUID('18e443ce-38fd-47c8-84d5-6d0c775fbe55')
ag.reload_glance(target_app=watchfaces_app_uuid, slices=my_slices)
```
