### PR TITLE
Fix broken PULSE transport import, bump to 0.0.22

### DIFF
--- a/libpebble2/communication/transports/pulse.py
+++ b/libpebble2/communication/transports/pulse.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 __author__ = 'Liam McLoughlin'
 
+import time
 import struct
 
 try:

--- a/libpebble2/version.py
+++ b/libpebble2/version.py
@@ -1,4 +1,4 @@
 __author__ = 'katharine'
 
-__version_info__ = (0, 0, 21)
+__version_info__ = (0, 0, 22)
 __version__ = '.'.join(map(str, __version_info__))


### PR DESCRIPTION
We need to bump pebble-tool's libpebble2 dependency for PULSE support, and since this is broken in PyPi we'll have to version bump unfortunately. Apologies!
