### PR TITLE
Add `QemuContentSize` protocol type

### DIFF
--- a/libpebble2/communication/transports/qemu/protocol.py
+++ b/libpebble2/communication/transports/qemu/protocol.py
@@ -80,6 +80,16 @@ class QemuTimelinePeek(PebblePacket):
     enabled = Boolean()
 
 
+class QemuContentSize(PebblePacket):
+    class ContentSize(IntEnum):
+        Small = 0
+        Medium = 1
+        Large = 2
+        ExtraLarge = 3
+
+    size = Uint8()
+
+
 class QemuPacket(PebblePacket):
     signature = Uint16(default=HEADER_SIGNATURE)
     protocol = Uint16()
@@ -94,6 +104,7 @@ class QemuPacket(PebblePacket):
         8: QemuButton,
         9: QemuTimeFormat,
         10: QemuTimelinePeek,
+        11: QemuContentSize,
     }, length=length)
     footer = Uint16(default=FOOTER_SIGNATURE)
 


### PR DESCRIPTION
Adds a new QEMU protocol type that can be used to change the firmware's system content size. See companion firmware PR here: https://phabricator.marlinspike.hq.getpebble.com/D7162

Here's a script you can use to test the change with the firmware PR. Running this script will update the system content size to "Small" and then exit the currently running app to "force" the UI to respect the new content size:

```
from libpebble2.communication.transports.qemu.protocol import QemuContentSize
from libpebble2.communication import PebbleConnection
from libpebble2.communication.transports.qemu import MessageTargetQemu, QemuTransport

transport = QemuTransport('127.0.0.1')
pebble = PebbleConnection(transport)
pebble.connect()
pebble.run_async()

pebble.transport.send_packet(QemuContentSize(size=QemuContentSize.ContentSize.Small),
                                             target=MessageTargetQemu())
```
